### PR TITLE
Código de Transmissão Santander

### DIFF
--- a/samples/ExemploRemessaSantander.php
+++ b/samples/ExemploRemessaSantander.php
@@ -31,6 +31,13 @@ require_once ("../autoloader.php");
 
 use CnabPHP\Remessa;
 
+// Exemplo de código de transmissão:
+// AGÊNCIA(4 dígitos) + 0000 (zeros fixo) + CONVENIO (7 dígitos)
+// AG: 1234
+// Fixo: 0000
+// Convênio: 0123456
+// Código de Transmissão será: 123400000123456
+
 $arquivo = new Remessa("033",'cnab240',array(
     'nome_empresa' =>"Empresa ABC", // seu nome de empresa
     'tipo_inscricao'  => 2, // 1 para cpf, 2 cnpj
@@ -39,7 +46,6 @@ $arquivo = new Remessa("033",'cnab240',array(
     'agencia_dv'    => 6, // somente o digito verificador da agencia
     'conta'         => '12345678', // número da conta
     'conta_dv'     => 9, // digito da conta
-    'codigo_transmissao' => '12345678901234567890',
      'codigo_beneficiario'     => '10668', // codigo fornecido pelo banco
      'codigo_beneficiario_dv'     => '2', // codigo fornecido pelo banco
      'numero_sequencial_arquivo'     => 1,
@@ -47,7 +53,7 @@ $arquivo = new Remessa("033",'cnab240',array(
 ));
 
 
-$lote  = $arquivo->addLote(array('tipo_servico'=> 1,'codigo_transmissao' => '12345678901234567890')); // tipo_servico  = 1 para cobrança registrada, 2 para sem registro
+$lote  = $arquivo->addLote(array('tipo_servico'=> 1)); // tipo_servico  = 1 para cobrança registrada, 2 para sem registro
 
 $lote->inserirDetalhe(array(
     'conta_cobranca' => '12345678', // número da conta cobranca obs(verificar se eh o mesmo da conta movimento)

--- a/src/resources/B033/remessa/cnab240/Registro0.php
+++ b/src/resources/B033/remessa/cnab240/Registro0.php
@@ -80,13 +80,7 @@ class Registro0 extends Generico0
             'required' => true
         ),
         'codigo_beneficiario' => array(
-            'tamanho' => 6,
-            'default' => '0',
-            'tipo' => 'int',
-            'required' => true
-        ),
-        'codigo_beneficiario_dv' => array(
-            'tamanho' => 1,
+            'tamanho' => 7,
             'default' => '0',
             'tipo' => 'int',
             'required' => true

--- a/src/resources/B033/remessa/cnab240/Registro1.php
+++ b/src/resources/B033/remessa/cnab240/Registro1.php
@@ -110,13 +110,7 @@ class Registro1 extends Generico1
             'required' => true
         ),
         'codigo_beneficiario' => array(
-            'tamanho' => 6,
-            'default' => '0',
-            'tipo' => 'int',
-            'required' => true
-        ),
-        'codigo_beneficiario_dv' => array(
-            'tamanho' => 1,
+            'tamanho' => 7,
             'default' => '0',
             'tipo' => 'int',
             'required' => true


### PR DESCRIPTION
Olá, tudo bem?

Estava quebrando a cabeça hoje de manhã sobre o porquê de o código de transmissão gerado na remessa não bater com o código de transmissão que especifiquei no código, e descobri que a biblioteca não usa o mesmo, apesar de estar na documentação. Estou agora fazendo homologação do Santander, e conversando com a responsável do banco, nem fui informado do dígito verificador, somente do código do cedente. 

O código de transmissão era para ser o seguinte: 332100000256940, com 3321 sendo a agência, seguido de quatro 0s, e, por fim, o código do cedente, 0256940. A biblioteca gera: 332100002569400, quase tudo correto, exceto pelo fato de que o tamanho especificado no OpenCnabPHP para o código do cedente é 6, quando deveria ser 7, e o dígito verificador não deveria ser levado em conta.

Vi isso sendo mencionado em outros issues já, como #84, ou #65.

O que estou falando faz sentido, ou existe algum outro caso em que isso pode ser um problema?

Agradeço desde já, abraços.