### PR TITLE
Corrige bug de cod banco com menos de 3 digitos ex 033

### DIFF
--- a/src/RegistroRemAbstract.php
+++ b/src/RegistroRemAbstract.php
@@ -108,7 +108,7 @@ abstract class RegistroRemAbstract extends RegistroAbstract {
                     $retorno = (($this->data[$prop] && trim($this->data[$prop]) !== "" ? number_format($this->data[$prop], $metaData['precision'], '', '') : (isset($metaData['default']) ? $metaData['default'] : '')));
                     return str_pad($retorno, $metaData['tamanho'] + $metaData['precision'], '0', STR_PAD_LEFT);
                 case 'int':
-                    $retorno = (isset($this->data[$prop]) && trim($this->data[$prop]) !== "" ? number_format($this->data[$prop], 0, '', '') : (isset($metaData['default']) ? $metaData['default'] : ''));
+                    $retorno = (isset($this->data[$prop]) && trim($this->data[$prop]) !== "" (gettype($this->data[$prop]) === 'integer') ? number_format($this->data[$prop], 0, '', '') : (isset($metaData['default']) ? $metaData['default'] : ''));
                     return str_pad($retorno, $metaData['tamanho'], '0', STR_PAD_LEFT);
                 case 'alfa':
                     $retorno = (isset($this->data[$prop])) ? $this->prepareText($this->data[$prop]) : '';

--- a/src/RegistroRemAbstract.php
+++ b/src/RegistroRemAbstract.php
@@ -108,7 +108,7 @@ abstract class RegistroRemAbstract extends RegistroAbstract {
                     $retorno = (($this->data[$prop] && trim($this->data[$prop]) !== "" ? number_format($this->data[$prop], $metaData['precision'], '', '') : (isset($metaData['default']) ? $metaData['default'] : '')));
                     return str_pad($retorno, $metaData['tamanho'] + $metaData['precision'], '0', STR_PAD_LEFT);
                 case 'int':
-                    $retorno = (isset($this->data[$prop]) && trim($this->data[$prop]) !== "" (gettype($this->data[$prop]) === 'integer') ? number_format($this->data[$prop], 0, '', '') : (isset($metaData['default']) ? $metaData['default'] : ''));
+                    $retorno = (isset($this->data[$prop]) && trim($this->data[$prop]) !== "" && (gettype($this->data[$prop]) === 'integer') ? number_format($this->data[$prop], 0, '', '') : (isset($metaData['default']) ? $metaData['default'] : ''));
                     return str_pad($retorno, $metaData['tamanho'], '0', STR_PAD_LEFT);
                 case 'alfa':
                     $retorno = (isset($this->data[$prop])) ? $this->prepareText($this->data[$prop]) : '';


### PR DESCRIPTION
Ao tentar gerar arquivo de remessa de bancos que o código dele tem menos de 3 caracteres, (ex.: Santander -> 033, Banco do Brasil -> 001)  no método ___get do arquivo RegistroRemAbstract.php da erro ao executar a função number_format, essa função espera um inteiro ou float, como está recebendo uma string numerica onde tem 0 a esquerda uma exceção é lançada.
Coloquei uma verificação para passar somente inteiros para que não ocorra esse problema novamente.